### PR TITLE
Added dependency on Culturefeed Search UI to the Culturefeed Agenda module.

### DIFF
--- a/culturefeed_agenda/culturefeed_agenda.info
+++ b/culturefeed_agenda/culturefeed_agenda.info
@@ -5,5 +5,6 @@ version = VERSION
 core = 7.x
 
 dependencies[] = culturefeed_search
+dependencies[] = culturefeed_search_ui
 
 files[] = lib/Drupal/AgendaSearchPage.php


### PR DESCRIPTION
After enabling culturefeed_agenda and visiting agenda/search I got the following error:

Fatal error: Call to undefined function _culturefeed_search_ui_get_active_search_page() in culturefeed/culturefeed_agenda/culturefeed_agenda.module on line 438

culturefeed_agenda depends on culturefeed_search_ui.
