### PR TITLE
Culturefeed search dependency

### DIFF
--- a/culturefeed_search/culturefeed_search.info
+++ b/culturefeed_search/culturefeed_search.info
@@ -4,6 +4,8 @@ package = CultureFeed
 version = VERSION
 core = 7.x
 
+dependencies[] = culturefeed
+
 files[] = lib/Drupal/Import/CultureFeedDomainImport.php
 files[] = lib/Drupal/Import/CultureFeedCityImport.php
 files[] = lib/Drupal/Import/CnapiHeadingImport.php


### PR DESCRIPTION
When I do a clean install and enable the Culture Feed Search API module I get the following error:

> Fatal error: Class 'DrupalCultureFeed' not found in sites/all/modules/contrib/culturefeed/culturefeed_search/includes/helpers.inc on line 661

The Search module depends on the base Culture Feed module.
