### PR TITLE
Allow to override the title of search pages.

### DIFF
--- a/culturefeed_search_ui/lib/Drupal/CultureFeedSearchPage.php
+++ b/culturefeed_search_ui/lib/Drupal/CultureFeedSearchPage.php
@@ -425,7 +425,7 @@ class CultureFeedSearchPage {
   public function getDrupalTitle() {
     // Return the title that has been explicitly set with $this->setTitle().
     if (!empty($this->title)) {
-      return check_plain($this->title);
+      return $this->title;
     }
 
     $active_filters = module_invoke_all('culturefeed_search_ui_active_filters', $this->facetComponent);


### PR DESCRIPTION
The titles of search pages are generated by `CultureFeedSearchPage::getDrupalTitle()`. This method contains some oddly specific business logic which is not applicable to all websites. It is currently possible to supply a "default title" but this is only shown when no search facets are active. Short of extending the search page there is no way of customizing the title at this time.

Overall this method looks like it could use some love:
- It is retrieving the page number directly from the URL query arguments. This implies intimate knowledge of the calling framework (the culturefeed_search_ui module in this case). Ideally this should be stored in properties on the object, or retrieved from the `SearchResult` object (but this does not support paging atm).
- The method name `getDrupalTitle()` sounds strange, what is a drupal-title?
- When there are active search filters the page title is set to a comma-separated list of active search filters, and is appended with the Dutch word "pagina" (which is not translatable) and the page number in case there are multiple result pages. I assume this was originally implemented for a specific use case (perhaps the kickstarter?) without considering that other websites might want to use a different titling strategy.

The best solution would be to rewrite this method, generalize it and make it pluggable / themable, but this will probably break existing implementations.

I propose a quick fix, a `$title` property with a getter and setter which can be used to override the page title. If this is left empty the current logic will be executed. This allows websites to set the title to their liking, and will not break existing implementations.
