### PR TITLE
Links in search facet items are run through url() twice

### DIFF
--- a/culturefeed_search_ui/theme/culturefeed-search-facet-item.tpl.php
+++ b/culturefeed_search_ui/theme/culturefeed-search-facet-item.tpl.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Template file for one culturefeed search facet item.
+ * Template file for a single culturefeed search facet item.
  */
 
 /**
@@ -12,7 +12,7 @@
  */
 ?>
 <?php if ($active): ?>
-  <span class="facet-label active"><?php print check_plain($label); ?> <small class="muted">(<?php print $count; ?>)</small> <?php print l('<i class="icon-remove text-red pull-right icon-large"></i>', $url, array('attributes' => array('class' => 'facet-remove pull-right', 'title' => 'Verwijder filter'), 'html' => TRUE)); ?></span>
+  <span class="facet-label active"><?php print check_plain($label); ?> <small class="muted">(<?php print $count; ?>)</small> <a href="<?php print $url; ?>" class="facet-remove pull-right" title="<?php print t('Remove filter'); ?>"><i class="icon-remove text-red pull-right icon-large"></i></a></span>
 <?php else: ?>
-  <?php print '' . l($label, $url, array('html' => TRUE)); ?> <small class="muted facet-count">(<?php print $count; ?>)</small>
+  <a href="<?php print $url; ?>"><?php print check_plain($label); ?></a> <small class="muted facet-count">(<?php print $count; ?>)</small>
 <?php endif; ?>

--- a/culturefeed_search_ui/translations/culturefeed_search_ui.nl.po
+++ b/culturefeed_search_ui/translations/culturefeed_search_ui.nl.po
@@ -264,3 +264,7 @@ msgid "@range from @count result"
 msgid_plural "@range from @count results"
 msgstr[0] "@range van @count resultaat"
 msgstr[1] "@range van @count resultaten"
+
+#: theme/culturefeed-search-facet-item.tpl.php:15
+msgid "Remove filter"
+msgstr "Verwijder filter"


### PR DESCRIPTION
Links in search facet items are run through `url()` twice, once in the preprocess function:

``` php
function culturefeed_search_ui_preprocess_culturefeed_search_facet_item(&$variables) {
  // ...
  $variables['url'] = url($variables['path'], array('query' => $query, 'absolute' => TRUE));
  // ...
}
```

... and once in the template, by calling the `l()` function, which runs the `$url` through `url()` again:

``` php
  ...
  <span class="facet-label active"><?php print check_plain($label); ?> <small class="muted">(<?php print $count; ?>)</small> <?php print l('<i class="icon-remove text-red pull-right icon-large"></i>', $url, array('attributes' => array('class' => 'facet-remove pull-right', 'title' => 'Verwijder filter'), 'html' => TRUE)); ?></span>
  ...
  <?php print '' . l($label, $url, array('html' => TRUE)); ?> <small class="muted facet-count">(<?php print $count; ?>)</small>
  ...
```

This is wreaking havoc on my website's `hook_url_outbound_alter()` implementation.

In passing I also fixed an untranslated string.
