### PR TITLE
Add type to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "cultuurnet/culturefeed",
+    "type": "drupal-module",
     "description": "CultuurNet culturefeed PHP library & Drupal module",
     "license": "Apache-2.0",
     "require": {


### PR DESCRIPTION
Needed for installer-paths support.

This will enable me to do the following, so the module suite will be installed in a separate directory:

```
{
    "require": {
        "composer/installers": "1.0.*",
        "cultuurnet/cdb": "2.*@dev",
        "cultuurnet/culturefeed": "dev-installer-paths"
    },
    "extra": {
        "installer-paths": {
            "sites/all/modules/vendor/{$name}": ["type:drupal-module"]
        }
    }
}
```
