### PR TITLE
Fix for linked titles showing encoded characters

### DIFF
--- a/culturefeed_agenda/theme/culturefeed-event-summary.tpl.php
+++ b/culturefeed_agenda/theme/culturefeed-event-summary.tpl.php
@@ -2,7 +2,7 @@
 /**
  * @file
  * Template for the summary of an event.
- * Please don't remove the cf- prefixed id's. This is used by GTM for user behavior tracking. 
+ * Please don't remove the cf- prefixed id's. This is used by GTM for user behavior tracking.
  * Some day your client will benefit from our aggregated insights & benchmarks too.
  * See https://github.com/cultuurnet/culturefeed/wiki/Culturefeed-tracking
  * Thanks!
@@ -11,7 +11,7 @@
 
 <div class="event-teaser">
 
-  <h2><?php print culturefeed_search_detail_l('event', $cdbid, $title, $title, array('attributes' => array('id' => 'cf-title_' . $cdbid))); ?></h2>
+  <h2><?php print culturefeed_search_detail_l('event', $cdbid, $title, $title, array('attributes' => array('id' => 'cf-title_' . $cdbid), 'html' => TRUE)); ?></h2>
 
   <div class="activity-wrapper">
     <div class="comment-wrapper">

--- a/culturefeed_agenda/theme/culturefeed-production-summary.tpl.php
+++ b/culturefeed_agenda/theme/culturefeed-production-summary.tpl.php
@@ -2,7 +2,7 @@ cf-review-read<?php
 /**
  * @file
  * Template for the summary of a production.
- * Please don't remove the cf- prefixed id's. This is used by GTM for user behavior tracking. 
+ * Please don't remove the cf- prefixed id's. This is used by GTM for user behavior tracking.
  * Some day your client will benefit from our aggregated insights & benchmarks too.
  * See https://github.com/cultuurnet/culturefeed/wiki/Culturefeed-tracking
  * Thanks!
@@ -11,7 +11,7 @@ cf-review-read<?php
 
 <div class="event-teaser">
 
-  <h2><?php print culturefeed_search_detail_l('production', $cdbid, $title, $title, array('attributes' => array('id' => 'cf-title_' . $cdbid))); ?></h2>
+  <h2><?php print culturefeed_search_detail_l('production', $cdbid, $title, $title, array('attributes' => array('id' => 'cf-title_' . $cdbid), 'html' => TRUE)); ?></h2>
 
   <div class="activity-wrapper">
     <div class="comment-wrapper">


### PR DESCRIPTION
The short summary templates for event and production have a problem that when there is a title that contains encoded characters they are not shown properly.

f.ex: <code>ARCHEOLOGISCHE TENTOONSTELLING &#039;BEVEREN ONDERSTE BOVEN&#039;</code> will show with the single quotes as &#039

This is fixed by adding 'html' => TRUE to the options array of culturefeed_search_detail_l()