### PR TITLE
Fix fatal error when min_age query parameter is not an array

### DIFF
--- a/culturefeed_search_ui/theme/theme.inc
+++ b/culturefeed_search_ui/theme/theme.inc
@@ -412,6 +412,12 @@ function culturefeed_search_ui_preprocess_culturefeed_search_facet_item(&$variab
   $facet_item = $variables['facet_item'];
   $query = $variables['query'];
 
+  // Prevent fatal errors later on in this function when the min_age
+  // URL query parameter is not an array.
+  if (isset($query['min_age']) && !is_array($query['min_age'])) {
+    $query['min_age'] = array();
+  }
+
   // Create array with facet_keys that should support multiple select/unselect.
   // Don't add 'agefrom as this is not handled as a facet.
   $multiple_facet_keys = array(


### PR DESCRIPTION
When in the path of the agenda search page you specify e.g. ?min_age=18, fatal errors occur in theme.inc of culturefeed_search_ui, because it expects it to be an array.

```
PHP Fatal error:  [] operator not supported for strings in .../modules/culturefeed/culturefeed_search_ui/theme/theme.inc on line 490
```
