### PR TITLE
110: Added support to load the culturefeed library using the composer_manager module.

### DIFF
--- a/culturefeed.module
+++ b/culturefeed.module
@@ -87,7 +87,7 @@ function culturefeed_menu() {
   $items['culturefeed/oauth/connect/register'] = array(
     'title' => 'Connect',
     'page callback' => 'culturefeed_oauth_connect',
-    'page arguments' => array(CultureFeed::AUTHORIZE_TYPE_REGISTER),
+    'page arguments' => array('register'),
     'access callback' => TRUE,
     'type' => MENU_CALLBACK,
     'file' => 'culturefeed.pages.inc',

--- a/culturefeed_ui/culturefeed_ui.module
+++ b/culturefeed_ui/culturefeed_ui.module
@@ -200,7 +200,7 @@ function culturefeed_ui_theme() {
       'template' => 'culturefeed-ui-privacy-settings',
     ),
     'culturefeed_ui_most_active_user' => array(
-      'variables' => array('account' => NULL, 'sort' => CultureFeed_SearchUsersQuery::SORT_NUMBEROFACTIVEACTIVITIES),
+      'variables' => array('account' => NULL, 'sort' => 'numberOfActiveActivities'),
       'template' => 'culturefeed-ui-most-active-user',
     ),
     'culturefeed_ui_connect' => array(

--- a/culturefeed_uitpas/views/culturefeed_uitpas.views.inc
+++ b/culturefeed_uitpas/views/culturefeed_uitpas.views.inc
@@ -60,7 +60,7 @@ function culturefeed_uitpas_views_data() {
     ),
     'sort' => array(
       'handler' => 'culturefeed_uitpas_views_handler_sort',
-      'sort_property' => CultureFeed_Uitpas_Passholder_Query_SearchPromotionPointsOptions::SORT_TITLE,
+      'sort_property' => 'TITLE',
     ),
   );
 
@@ -72,7 +72,7 @@ function culturefeed_uitpas_views_data() {
     ),
     'sort' => array(
       'handler' => 'culturefeed_uitpas_views_handler_sort',
-      'sort_property' => CultureFeed_Uitpas_Passholder_Query_SearchPromotionPointsOptions::SORT_POINTS,
+      'sort_property' => 'POINTS',
     ),
   );
 
@@ -143,7 +143,7 @@ function culturefeed_uitpas_views_data() {
     ),
     'sort' => array(
       'handler' => 'culturefeed_uitpas_views_handler_sort',
-      'sort_property' => CultureFeed_Uitpas_Passholder_Query_SearchPromotionPointsOptions::SORT_CASHING_PERIOD_END,
+      'sort_property' => 'CASHING_PERIOD_END',
     ),
   );
 
@@ -152,7 +152,7 @@ function culturefeed_uitpas_views_data() {
     'help' => t("The creation date of the promotion."),
     'sort' => array(
       'handler' => 'culturefeed_uitpas_views_handler_sort',
-      'sort_property' => CultureFeed_Uitpas_Passholder_Query_SearchPromotionPointsOptions::SORT_CREATION_DATE,
+      'sort_property' => 'CREATION_DATE',
     ),
   );
 


### PR DESCRIPTION
Replacing the `CultureFeed::AUTHORIZE_TYPE_REGISTER` page argument by the string `register` fixes the error when installing the module when composer_manager is in use.

See #110