### PR TITLE
UIV-1916 allow searches on datetype=today to be indexed by robots

### DIFF
--- a/culturefeed_search_ui/includes/helpers.inc
+++ b/culturefeed_search_ui/includes/helpers.inc
@@ -291,6 +291,33 @@ function culturefeed_search_ui_set_noindex_metatag() {
 
     }
 
+    // No index is FALSE, if user is filtering on datetype today and max 1 flandersregion Id.
+    elseif (isset($query['facet']['datetype'])) {
+
+      if ($query['facet']['datetype'][0] == 'today') {
+
+        $facets = $query['facet'];
+        unset($facets['datetype']);
+
+        if (isset($query['facet']['category_flandersregion_id'])) {
+
+          if(count($query['facet']['category_flandersregion_id']) == 1) {
+            unset($facets['category_flandersregion_id']);
+          }
+
+        }
+        
+        unset($query['facet']);
+
+        // If datetype today was the only filter with max 1 flandersregion Id set noindex to false.
+        if (count($facets) == 0 && count($query) == 0) {
+          $noindex = FALSE;
+        }
+
+      }
+
+    }
+
     // No index is FALSE, if user is filtering on flandersregion Id.
     elseif (isset($query['facet']['category_flandersregion_id'])) {
 


### PR DESCRIPTION
Since the term "Vandaag" is widely used as a Google Search term by people looking for events in a particular region, we decided to let these search result pages be indexed by robots. 

A few examples of pages that are now being indexed (that weren't before):
- https://www.uitinvlaanderen.be/agenda/search?facet[datetype][0]=today
- https://www.uitinvlaanderen.be/agenda/alle/brugge?facet[datetype][0]=today
- https://www.uitinvlaanderen.be/agenda/alle/9040-sint-amandsberg-gent?facet[datetype][0]=today

These pages are not being indexed, but some of them might be candidates for the future.
- https://www.uitinvlaanderen.be/agenda/search?facet[datetype][0]=tomorrow
- https://www.uitinvlaanderen.be/agenda/alle/brugge?facet[datetype][0]=today&theme=schilderkunst
- https://www.uitinvlaanderen.be/agenda/concert/9040-sint-amandsberg-gent?facet[datetype][0]=today
