### PR TITLE
UIV-1933 add setting to hide all webresource links

### DIFF
--- a/culturefeed_agenda/includes/admin.inc
+++ b/culturefeed_agenda/includes/admin.inc
@@ -27,6 +27,13 @@ function culturefeed_agenda_admin_settings_form() {
     '#description' => t('Check this checkbox if you want to have culturefeed_social links in the template variables.'),
   );
 
+  $form['culturefeed_agenda_hide_webresources'] = array(
+    '#title' => t('Hide deprecated links stored as mediatype webresource or website'),
+    '#type' => 'checkbox',
+    '#default_value' => variable_get('culturefeed_agenda_hide_webresources', TRUE),
+    '#description' => t('By enabling this the event detail page will only show url\'s in the contactinfo object of cdbxml.'),
+  );
+
   $form['gmap'] = array(
     '#type' => 'fieldset',
     '#collapsible' => TRUE,

--- a/culturefeed_agenda/includes/helpers.inc
+++ b/culturefeed_agenda/includes/helpers.inc
@@ -92,7 +92,7 @@ function _culturefeed_agenda_get_links_from_item(CultureFeed_Cdb_Item_Base $item
   }
 
   // General links.
-  if ($detail) {
+  if ($detail && variable_get('culturefeed_agenda_hide_webresources', TRUE)) {
 
     foreach ($detail->getMedia() as $media) {
       if ($media->getMediaType() == CultureFeed_Cdb_Data_File::MEDIA_TYPE_WEBRESOURCE || $media->getMediaType() == CultureFeed_Cdb_Data_File::MEDIA_TYPE_WEBSITE) {


### PR DESCRIPTION
Links that are stored as mediatype webresource or website cannot be updated or deleted through UDB3. Depending on the context of your site or application, it can be interesting to completely hide these "deprecated" links.

By enabling this setting, the event detail page will only show url\'s in the contactinfo object of cdbxml. All deprecated links stored as mediatype webresource or website will be hidden.

The only possible downside of enabling this, is that old events won't show any links as long as they are not edited or updated in UDB3 and posted as URL to the contactinfo object of cdbxml. 

