### PR TITLE
UIV-1940 check if actor exists before using it in event

### DIFF
--- a/culturefeed_agenda/includes/helpers.inc
+++ b/culturefeed_agenda/includes/helpers.inc
@@ -238,8 +238,9 @@ function culturefeed_agenda_get_location_of_event(CultureFeed_Cdb_Item_Event $ev
     if ($event->getCdbid()) {
       $location['cdbid_event'] = $event->getCdbid();
     }
-    if ($event->getLocation()->getCdbid()) {
-      $location['link'] = culturefeed_search_detail_l('actor', $event->getLocation()->getCdbid(), $location['title']);
+    $location_id = $event->getLocation()->getCdbid();
+    if ($location_id && is_object(culturefeed_agenda_actor_load($location_id))) {
+      $location['link'] = culturefeed_search_detail_l('actor', $location_id, $location['title']);
     }
     if ($location_info->getActor()) {
       $actor_detail = $location_info->getActor()->getDetails()->getDetailByLanguage(culturefeed_search_get_preferred_language());

--- a/culturefeed_agenda/theme/theme.inc
+++ b/culturefeed_agenda/theme/theme.inc
@@ -502,12 +502,11 @@ function _culturefeed_agenda_preprocess_agenda_detail(&$variables) {
       else if (is_object(culturefeed_agenda_actor_load($actor_id))) {
         $actor = culturefeed_agenda_actor_load($actor_id)->getEntity();
       }
-      else $actor = FALSE;
     }
-      if ($actor) {
-        $facilities = culturefeed_agenda_get_category_list_of_item(CultureFeed_Cdb_Data_Category::CATEGORY_TYPE_FACILITY, $actor);
-        $variables['locations_facilities'] = $facilities['text'];
-      }
+    if (isset($actor)) {
+      $facilities = culturefeed_agenda_get_category_list_of_item(CultureFeed_Cdb_Data_Category::CATEGORY_TYPE_FACILITY, $actor);
+      $variables['locations_facilities'] = $facilities['text'];
+    }
   }
 
   // Enhance event-details with UiTPAS-information if culturefeed_uitpas is enabled

--- a/culturefeed_agenda/theme/theme.inc
+++ b/culturefeed_agenda/theme/theme.inc
@@ -496,12 +496,18 @@ function _culturefeed_agenda_preprocess_agenda_detail(&$variables) {
   if ($cdb_item instanceof CultureFeed_Cdb_Item_Event) {
     $actor_id = $cdb_item->getLocation()->getCdbid();
     if ($actor_id) {
-      $actor = $cdb_item->getLocation()->getActor() ?: culturefeed_agenda_actor_load($actor_id)->getEntity();
+      if ($cdb_item->getLocation()->getActor()) {
+        $actor = $cdb_item->getLocation()->getActor();
+      }
+      else if (is_object(culturefeed_agenda_actor_load($actor_id))) {
+        $actor = culturefeed_agenda_actor_load($actor_id)->getEntity();
+      }
+      else $actor = FALSE;
+    }
       if ($actor) {
         $facilities = culturefeed_agenda_get_category_list_of_item(CultureFeed_Cdb_Data_Category::CATEGORY_TYPE_FACILITY, $actor);
         $variables['locations_facilities'] = $facilities['text'];
       }
-    }
   }
 
   // Enhance event-details with UiTPAS-information if culturefeed_uitpas is enabled


### PR DESCRIPTION
When an actor object has been deleted, the title and cdbid is not removed from an event detail in cdbxml. Since merging pull request CF-425, deleted actor requests will returns a 404 or 410-respons and loading an event will invoke a "fatal error".

The provided solution is to check if actor is an object before using location facilities or location link in event detail pages.

Testing can be done with these examples:

1. https://www.uitinvlaanderen.be/agenda/e/feestmarkt-zwijndrecht/8e3ff8eb-91e5-4b59-9991-85e363c91cfb
- After applying this hotfix:
-- This event shouldn't throw a fatal error anymore
-- The location title shouldn't be clickable anymore
2. https://www.uitinvlaanderen.be/agenda/e/waar-muziek-echt-over-gaat-muzikaal-geillustreerd/a3cbec63-9698-420b-9a19-524c54e7ea17
-- To check if the location_facilities are still loaded for existing actors, you should see a green/blue facility icon + tooltip next to the location title