### PR TITLE
BVV-1234 make it possible to load unavailable events for writing reviews

### DIFF
--- a/culturefeed_search/includes/helpers.inc
+++ b/culturefeed_search/includes/helpers.inc
@@ -48,6 +48,7 @@ function culturefeed_search_item_load($cdb_id, $type = '', $watchdog = TRUE) {
     $parameters = array();
     $parameters[] = new \CultuurNet\Search\Parameter\Group();
     $parameters[] = new \CultuurNet\Search\Parameter\Parameter("past", "true");
+    $parameters[] = new \CultuurNet\Search\Parameter\Parameter("unavailable", "true");
     $parameters[] = new \CultuurNet\Search\Parameter\Query('cdbid:' . $cdb_id);
 
     try {


### PR DESCRIPTION
Not very sure about possible side effects of adding unavailable=true as global parameter to the culturefeed_search_item_load() function.

Maybe it's better to use a new optional argument for adding the unavailable parameter to the search query?