### PR TITLE
Support protocol-relative URLs coming from UiTdatabank

### DIFF
--- a/culturefeed_entry_ui/includes/culturefeed_entry_ui.pages.inc
+++ b/culturefeed_entry_ui/includes/culturefeed_entry_ui.pages.inc
@@ -216,7 +216,7 @@ function culturefeed_entry_ui_event_form($form, &$form_state, $event = NULL) {
       }
 
       try {
-        $pattern = '#^https?://#';
+        $pattern = '#^(https?:)?//#';
         $image_link = preg_replace($pattern, '', $main_image->getHLink());
         $default_image = system_retrieve_file('http://' . $image_link, 'public://uploads/', TRUE);
 


### PR DESCRIPTION
Symptoms:
* Error message "HTTP error @errorcode occurred when trying to fetch @remote." triggered when trying to fetch the main  image when editing an existing event with the culturefeed_entry_ui module
* File usage of the main image will not get registered

Cause:
* culturefeed_entry_ui does not fully take into account that UDB now contains protocol-relative URLs, and tries to download an image with an invalid URI (http:////)