### PR TITLE
UIV-2009 find right index of group parameter before unsetting it

### DIFF
--- a/culturefeed_search_ui/culturefeed_search_ui.module
+++ b/culturefeed_search_ui/culturefeed_search_ui.module
@@ -960,7 +960,16 @@ function culturefeed_search_ui_culturefeed_search_page_query_alter(CultureFeedSe
 
   // If group = event and we are looking for movies switch to group = event_production
   if ($culturefeedSearchPage->getGroup() == 'event' && (isset($_GET['facet']['category_eventtype_id']) && in_array('0.50.6.0.0', $_GET['facet']['category_eventtype_id']))) {
-    $culturefeedSearchPage->unsetParameter(7);
+    // Find index of group parameter
+    $params = $culturefeedSearchPage->getParameters();
+    for ($i = 0; $i <= count($params); $i++) {
+      $name = get_class($params[$i]);
+      if ($name == 'CultuurNet\Search\Parameter\Group') {
+        $key = $i;
+        break;
+      }
+    }
+    $culturefeedSearchPage->unsetParameter($key);
     $culturefeedSearchPage->addParameter(new Parameter\Parameter('group', 'event_production'));
     $culturefeedSearchPage->setGroup('event_production');
   }


### PR DESCRIPTION
**Problem:**
Unsetting parameter with fixed index of 7 will delete rows parameter when datetype or daterange parameter is active. 

**Solution:**
First look for index of Group parameter before unsetting it. We do this on classname since keys are protected.