### PR TITLE
custom filter options not appearing in active filters block

### DIFF
--- a/culturefeed_search_ui/culturefeed_search_ui.module
+++ b/culturefeed_search_ui/culturefeed_search_ui.module
@@ -1279,16 +1279,10 @@ function culturefeed_search_ui_culturefeed_search_ui_active_filters($culturefeed
   for ($i = 1; $i <= CULTUREFEED_SEARCH_TOTAL_FILTER_BLOCKS; $i++) {
 
     if ($i == 1) {
-      $block = block_load('culturefeed_search_ui', 'filter-form');
-      if ($block->status) {
-        $extra_filter_options = variable_get('culturefeed_search_filter_options', culturefeed_search_ui_default_filter_options($i));
-      }
+      $extra_filter_options = variable_get('culturefeed_search_filter_options', culturefeed_search_ui_default_filter_options($i));
     }
     else {
-      $block = block_load('culturefeed_search_ui', 'filter-form-' . $i);
-      if ($block->status) {
-        $extra_filter_options = variable_get('culturefeed_search_filter_options_' . $i, culturefeed_search_ui_default_filter_options($i));
-      }
+      $extra_filter_options = variable_get('culturefeed_search_filter_options_' . $i, culturefeed_search_ui_default_filter_options($i));
     }
 
     $filter_options = array_merge($filter_options, $extra_filter_options);


### PR DESCRIPTION
This reverts pull-request 156 "do not override filter options when filter-form blocks are not activated" (commit a68ec7315d6cf5209be7b38008cdc912c042a832)

This commit caused custom filter options not appearing at all in the active filters block when the custom filter form block was enabled in another theme then the active one.