### PR TITLE
add helper function to get active search api environment

### DIFF
--- a/culturefeed_search/includes/helpers.inc
+++ b/culturefeed_search/includes/helpers.inc
@@ -1013,6 +1013,20 @@ function culturefeed_search_acceptance_mode() {
 }
 
 /**
+ * Get the active Search API environment.
+ */
+function culturefeed_search_active_environment() {
+
+  // Get culturefeed_search_api_location
+  $location = variable_get('culturefeed_search_api_location');
+  $host = parse_url($location, PHP_URL_HOST);
+  $environment = explode('.', $host)[0];
+
+  return $environment;
+
+}
+
+/**
  * Set the "noindex, follow" meta tag when needed.
  */
 function culturefeed_search_set_noindex_metatag() {


### PR DESCRIPTION
Since the search api location can be set to 3 different endpoints, the function culturefeed_search_acceptance_mode() which returns TRUE (for both TEST and ACC) or FALSE (for PROD) won't do anymore.

A new helper function culturefeed_search_active_environment() will now return a string www, acc or test depending on which search api location is set. This can be used to create the right shortcuts to other applications (XML, JSON, UDB3, UID admin,...).