### PR TITLE
BVV-1381 uncomment culturefeed_mailing_subscribe_user_light

### DIFF
--- a/culturefeed_mailing/culturefeed_mailing.module
+++ b/culturefeed_mailing/culturefeed_mailing.module
@@ -362,7 +362,7 @@ function culturefeed_mailing_newsletter_block_form_validate($form, $form_state) 
 
     try {
       $zip = !empty($form_state['values']['zip']) ? $form_state['values']['zip'] : '';
-      //culturefeed_mailing_subscribe_user_light($form_state['values']['mail'], variable_get('culturefeed_mailing_list', ''), $zip);
+      culturefeed_mailing_subscribe_user_light($form_state['values']['mail'], variable_get('culturefeed_mailing_list', ''), $zip);
     }
     catch (CultureFeed_Exception $e) {
 


### PR DESCRIPTION
Light users weren't able to subscribe to culturefeed_mailings. Uncommenting this function fixes this problem, but maybe there was a particular reason to comment this line for the data_validation,...?

Can you review this pull request @zuuperman ?

Thanks