### PR TITLE
CF-510 randomize drupal user name to fix db insert issue

### DIFF
--- a/culturefeed.helpers.inc
+++ b/culturefeed.helpers.inc
@@ -39,7 +39,8 @@ function culturefeed_is_culturefeed_user($uid = NULL) {
 function culturefeed_unique_username($cf_uid, $nick) {
 
   if (!$nick) {
-    $nick = t('Anonymous');
+    $suffix = substr($cf_uid, -4);
+    $nick = t('Anonymous') . '_' . $suffix;
   }
 
   $name = db_query("SELECT DISTINCT name FROM {culturefeed_user} cfu INNER JOIN {users} u ON u.uid = cfu.uid WHERE cfu.cf_uid = :cf_uid", array(':cf_uid' => $cf_uid))->fetchField();


### PR DESCRIPTION
Randomize the drupal user name for anonymous users to avoid it from getting too long to insert in db. 

**Example:**
A user name like "Anoniem_1_2_3_4_5_6_7_8_9_10_11_12_13_14_15_16_17_18_19_20_21" could not be inserted in a name field with a length of 60
