### PR TITLE
CF-517 load event detail directly in related activities block

### DIFF
--- a/culturefeed_agenda/includes/blocks.inc
+++ b/culturefeed_agenda/includes/blocks.inc
@@ -11,19 +11,26 @@ use \CultuurNet\Search\Parameter;
  */
 function culturefeed_agenda_block_related_activities() {
 
-  // Try to load the agenda detail.
-  $item = culturefeed_agenda_get_active_object();
-  if (!$item || arg(4) == 'edit' || arg(4) == 'tags') {
+  // Only load related events on event detail pages
+  if (arg(1) != 'e') {
     return;
   }
 
-  $config = array(
-    'title' => t('Related activities'),
-    'id' => 'related-activities',
-    'path' => 'ajax/culturefeed/related-activities/' . $item->getId(),
-  );
-
-  return culturefeed_ui_block_ajaxload($config);
+  else {
+    // Try to load the agenda detail.
+    $item = culturefeed_agenda_get_active_object();
+    if (!$item || arg(4) == 'edit' || arg(4) == 'tags') {
+      return;
+    }
+  
+    $config = array(
+      'title' => t('Related activities'),
+      'id' => 'related-activities',
+      'path' => 'ajax/culturefeed/related-activities/' . $item->getId(),
+    );
+  
+    return culturefeed_ui_block_ajaxload($config);
+  }
 
 }
 

--- a/culturefeed_agenda/includes/pages.inc
+++ b/culturefeed_agenda/includes/pages.inc
@@ -134,12 +134,12 @@ function culturefeed_agenda_page_map(\CultuurNet\Search\ActivityStatsExtendedEnt
 }
 
 /**
- * Ajax callback: load the related activities for an item.
+ * Ajax callback: load the related activities for an event item.
  */
 function culturefeed_agenda_page_ajax_related_activities($cdb_id) {
 
   $data = '';
-  $item = culturefeed_search_item_load($cdb_id);
+  $item = culturefeed_search_item_load($cdb_id, 'event');
   if ($item) {
 
     $total_items = variable_get('agenda_related_activities_total_items', 3);
@@ -241,7 +241,6 @@ function culturefeed_agenda_page_ajax_related_activities($cdb_id) {
   else {
     $commands[] = ajax_command_remove('#block-culturefeed-agenda-agenda-related-activities');
   }
-
 
   ajax_deliver(array('#type' => 'ajax', '#commands' => $commands));
 


### PR DESCRIPTION
culturefeed_search_item_load($cdbid) without type parameter is performing a full search on cdbid in past & unavailable events

since this block has only results on event detail pages, we can limit the usage to event detail pages and load the event item directly with a faster detail request
